### PR TITLE
Bump log4j-core from 2.10.0 to 2.13.2 in /chapter10

### DIFF
--- a/chapter10/pom.xml
+++ b/chapter10/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.10.0</version>
+            <version>2.13.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Bumps log4j-core from 2.10.0 to 2.13.2.

Signed-off-by: dependabot[bot] <support@github.com>